### PR TITLE
Removed licensee stuff to fix problem

### DIFF
--- a/QC.Lic/Dockerfile
+++ b/QC.Lic/Dockerfile
@@ -1,13 +1,5 @@
 FROM python:3-slim
 LABEL maintainer="davrodgon@users.noreply.github.com"
 RUN pip3 install PyGithub python-gitlab
-COPY QC.Lic/checkLicense.py /
+COPY checkLicense.py /
 ENTRYPOINT [ "python","/checkLicense.py" ]
-
-FROM ruby:2.5
-RUN apt-get update && apt-get install -y \
-  cmake \
-  && rm -rf /var/lib/apt/lists/*
-WORKDIR /usr/src/app
-RUN gem install licensee
-COPY --from=0 /checkLicense.py .


### PR DESCRIPTION
Undo changes to Dockerfile to fix the broken docker image build. 
Not sure why these changes where needed here. 
In QC.Lic/licensee/Dockerfile (https://github.com/EOSC-synergy/sqa-composer-templates/blob/d23d5bb1d434c3680b081255789754b4dfc02846/QC.Lic/licensee/Dockerfile) you install licensee as well. 

If you don´t agree with reversing the changes, please fix the Dockerfile.